### PR TITLE
Add mortgage app chart

### DIFF
--- a/charts/mortgage-helm/Chart.yaml
+++ b/charts/mortgage-helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: mortgage-helm
+description: A sample mortgage helm chart
+version: 0.1.0
+appVersion: "1.16.0"

--- a/charts/mortgage-helm/templates/deployment.yaml
+++ b/charts/mortgage-helm/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mortgage-app-deploy
+  labels:
+    app: mortgage-app-mortgage
+spec:
+  selector:
+    matchLabels:
+      app: mortgage-app-mortgage
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mortgage-app-mortgage
+    spec:
+      containers:
+      - name: mortgage-app-mortgage
+        image: "quay.io/fxiang1/mortgage:0.5.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 9080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi

--- a/charts/mortgage-helm/templates/service.yaml
+++ b/charts/mortgage-helm/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mortgage-app-svc
+  labels:
+    app: mortgage-app-mortgage
+spec:
+  type: NodePort
+  ports:
+    - port: 9080
+      targetPort: 9080
+      protocol: TCP
+  selector:
+    app: mortgage-app-mortgage

--- a/git-sub/10-subscription-git-artifacts.yaml
+++ b/git-sub/10-subscription-git-artifacts.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   annotations:
-    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-branch: multiple-charts
     apps.open-cluster-management.io/github-path: git-sub
   name: local-git-artifacts-sub
   namespace: acm-lab

--- a/git-sub/10-subscription-mortgage.yaml
+++ b/git-sub/10-subscription-mortgage.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: mortgage-sub
+  name: mortgage-repo-sub
+  namespace: acm-lab
+spec:
+  channel: acm-channels/ch-lab-git
+  type: Git
+  placement:
+    local: true

--- a/git-sub/10-subscription-mortgage.yaml
+++ b/git-sub/10-subscription-mortgage.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   annotations:
-    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-branch: multiple-charts
     apps.open-cluster-management.io/github-path: mortgage-sub
   name: mortgage-repo-sub
   namespace: acm-lab

--- a/mortgage-sub/10-placement.yaml
+++ b/mortgage-sub/10-placement.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  labels:
+    app: mortgage
+  name: mortgage-placement-1
+  namespace: acm-lab
+spec:
+  clusterSelector:
+    matchLabels:
+      environment: demo

--- a/mortgage-sub/20-subscription.yaml
+++ b/mortgage-sub/20-subscription.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps.open-cluster-management.io/v1
+kind: Subscription
+metadata:
+  annotations:
+    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-path: charts/mortgage-helm
+  name: mortgage-chart-sub
+  namespace: acm-lab
+  labels:
+    app: mortgage
+spec:
+  channel: acm-channels/ch-lab-git
+  type: Git
+  placement:
+    placementRef:
+      kind: PlacementRule
+      name: mortgage-placement-1

--- a/mortgage-sub/20-subscription.yaml
+++ b/mortgage-sub/20-subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   annotations:
-    apps.open-cluster-management.io/github-branch: main
+    apps.open-cluster-management.io/github-branch: multiple-charts
     apps.open-cluster-management.io/github-path: charts/mortgage-helm
   name: mortgage-chart-sub
   namespace: acm-lab

--- a/mortgage-sub/30-application.yaml
+++ b/mortgage-sub/30-application.yaml
@@ -1,0 +1,16 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: mortgage
+  namespace: acm-lab
+spec:
+  componentKinds:
+  - group: apps.open-cluster-management.io
+    kind: Subscription
+  descriptor: {}
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: 
+          - mortgage


### PR DESCRIPTION
Add additional chart for mortgage app, tracked by a separate repo path subscription. 

This shows how multiple Helm charts can behosted in Git and tracked by individual subscriptions using the subscription-of-subscriptions model.